### PR TITLE
Empty history

### DIFF
--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -40,12 +40,10 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 	for _, dir := range dirs {
 		if dir.IsDir() {
 			historyFile := path.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
-			info, err := os.Stat(historyFile)
-			// If there is an error getting the history file or if the history file is empty do not append to Instance History
-			if err == nil {
+			if info, err := os.Stat(historyFile); err == nil {
+				// If there is an error getting the history file or if the history file is empty do not append to Instance History
 				if info.Size() == 0 {
-					path := path.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename)
-					c.Log.Infof("The history file exists at %v but is empty. Skipping this file...", path)
+					c.Log.Warnf("The history file exists at %s but is empty. Skipping this file...", historyFile)
 					continue
 				}
 				history, err := readHistoryFile(historyFile)

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -41,6 +41,10 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 		if dir.IsDir() {
 			historyFile := path.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
 			if info, err := os.Stat(historyFile); err == nil {
+				// Check to make sure info is a file and not a directory.
+				if !info.Mode().IsRegular() {
+					continue
+				}
 				// If there is an error getting the history file or if the history file is empty do not append to Instance History
 				if info.Size() == 0 {
 					c.Log.Warnf("The history file exists at %s but is empty. Skipping this file...", historyFile)

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -41,10 +41,11 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 		if dir.IsDir() {
 			historyFile := path.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
 			info, err := os.Stat(historyFile)
-			//If there is an error getting the history file or if the history file is empty do not append to Instance History
+			// If there is an error getting the history file or if the history file is empty do not append to Instance History
 			if err == nil {
 				if info.Size() == 0 {
-					c.Log.Info("The history file exists but is empty. Skipping this file...")
+					path := path.Join(c.HistoryPath, c.IMDS.InstanceID, c.HistoryFilename)
+					c.Log.Infof("The history file exists at %v but is empty. Skipping this file...", path)
 					continue
 				}
 				history, err := readHistoryFile(historyFile)

--- a/lib/ec2macosinit/instancehistory.go
+++ b/lib/ec2macosinit/instancehistory.go
@@ -40,7 +40,13 @@ func (c *InitConfig) GetInstanceHistory() (err error) {
 	for _, dir := range dirs {
 		if dir.IsDir() {
 			historyFile := path.Join(c.HistoryPath, dir.Name(), c.HistoryFilename)
-			if _, err := os.Stat(historyFile); err == nil {
+			info, err := os.Stat(historyFile)
+			//If there is an error getting the history file or if the history file is empty do not append to Instance History
+			if err == nil {
+				if info.Size() == 0 {
+					c.Log.Info("The history file exists but is empty. Skipping this file...")
+					continue
+				}
 				history, err := readHistoryFile(historyFile)
 				if err != nil {
 					return fmt.Errorf("ec2macosinit: error while reading history file at %s: %w", historyFile, err)


### PR DESCRIPTION
Added error handling for when the history file is empty but has no contents.